### PR TITLE
[add] CRUDを追加

### DIFF
--- a/internal/app/adapter/handler/resolver.go
+++ b/internal/app/adapter/handler/resolver.go
@@ -1,7 +1,11 @@
 package handler
 
+import "github.com/kenty51107/task-matcher/internal/app/usecase/port"
+
 // This file will not be regenerated automatically.
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
 
-type Resolver struct{}
+type Resolver struct{
+    TP port.ITaskPort
+}

--- a/internal/app/adapter/handler/schema.resolvers.go
+++ b/internal/app/adapter/handler/schema.resolvers.go
@@ -32,11 +32,11 @@ func (r *mutationResolver) UpdateTask(ctx context.Context, input model.UpdateTas
 
 // DeleteTask is the resolver for the deleteTask field.
 func (r *mutationResolver) DeleteTask(ctx context.Context, input model.DeleteTaskInput) (*model.Task, error) {
-	row, err := r.TP.DeleteTask(&input)
+	err := r.TP.DeleteTask(&input)
 	if err != nil {
 		return nil, err
 	}
-	return row, nil
+	return nil, nil
 }
 
 // GetTask is the resolver for the getTask field.
@@ -56,7 +56,6 @@ func (r *queryResolver) GetTasks(ctx context.Context) ([]*model.Task, error) {
 		return nil, err
 	}
 	return rows, nil
-
 }
 
 // Mutation returns generated.MutationResolver implementation.

--- a/internal/app/adapter/handler/schema.resolvers.go
+++ b/internal/app/adapter/handler/schema.resolvers.go
@@ -6,7 +6,7 @@ package handler
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 
 	"github.com/kenty51107/task-matcher/graph/generated"
 	"github.com/kenty51107/task-matcher/internal/app/domain/model"
@@ -14,17 +14,49 @@ import (
 
 // CreateTask is the resolver for the createTask field.
 func (r *mutationResolver) CreateTask(ctx context.Context, input model.CreateTaskInput) (*model.Task, error) {
-	panic(fmt.Errorf("not implemented: CreateTask - createTask"))
+	row, err := r.TP.CreateTask(&input)
+	if err != nil {
+		return nil, err
+	}
+	return row, nil
 }
 
 // UpdateTask is the resolver for the updateTask field.
 func (r *mutationResolver) UpdateTask(ctx context.Context, input model.UpdateTaskInput) (*model.Task, error) {
-	panic(fmt.Errorf("not implemented: UpdateTask - updateTask"))
+	row, err := r.TP.UpdateTask(&input)
+	if err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
+// DeleteTask is the resolver for the deleteTask field.
+func (r *mutationResolver) DeleteTask(ctx context.Context, input model.DeleteTaskInput) (*model.Task, error) {
+	row, err := r.TP.DeleteTask(&input)
+	if err != nil {
+		return nil, err
+	}
+	return row, nil
 }
 
 // GetTask is the resolver for the getTask field.
 func (r *queryResolver) GetTask(ctx context.Context, id string) (*model.Task, error) {
-	panic(fmt.Errorf("not implemented: GetTask - getTask"))
+	id_i, _ := strconv.Atoi(id)
+	row, err := r.TP.FindTaskByID(id_i)
+	if err != nil {
+		return nil, err
+	}
+	return row, nil
+}
+
+// GetTasks is the resolver for the getTasks field.
+func (r *queryResolver) GetTasks(ctx context.Context) ([]*model.Task, error) {
+	rows, err := r.TP.FindTasks()
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+
 }
 
 // Mutation returns generated.MutationResolver implementation.

--- a/internal/app/domain/model/task.go
+++ b/internal/app/domain/model/task.go
@@ -19,6 +19,10 @@ type CreateTaskInput struct {
 	Done     bool      `json:"done"`
 }
 
+type DeleteTaskInput struct {
+	ID string `json:"id"`
+}
+
 type UpdateTaskInput struct {
 	ID       string     `json:"id"`
 	Title    *string    `json:"title,omitempty"`

--- a/internal/app/domain/service/task_service.go
+++ b/internal/app/domain/service/task_service.go
@@ -7,5 +7,5 @@ type ITaskService interface {
     FindTasks() ([]*model.Task, error)
     CreateTask(*model.CreateTaskInput) (*model.Task, error)
     UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
-    DeleteTask(*model.DeleteTaskInput) (*model.Task, error)
+    DeleteTask(*model.DeleteTaskInput) error
 }

--- a/internal/app/domain/service/task_service.go
+++ b/internal/app/domain/service/task_service.go
@@ -1,0 +1,11 @@
+package service
+
+import "github.com/kenty51107/task-matcher/internal/app/domain/model"
+
+type ITaskService interface {
+    FindTaskByID(taskId int) (*model.Task, error)
+    FindTasks() ([]*model.Task, error)
+    CreateTask(*model.CreateTaskInput) (*model.Task, error)
+    UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
+    DeleteTask(*model.DeleteTaskInput) (*model.Task, error)
+}

--- a/internal/app/domain/service/task_service.go
+++ b/internal/app/domain/service/task_service.go
@@ -3,7 +3,7 @@ package service
 import "github.com/kenty51107/task-matcher/internal/app/domain/model"
 
 type ITaskService interface {
-    FindTaskByID(taskId int) (*model.Task, error)
+    FindTaskByID(taskID int) (*model.Task, error)
     FindTasks() ([]*model.Task, error)
     CreateTask(*model.CreateTaskInput) (*model.Task, error)
     UpdateTask(*model.UpdateTaskInput) (*model.Task, error)

--- a/internal/app/infra/datastore/task_datastore.go
+++ b/internal/app/infra/datastore/task_datastore.go
@@ -1,0 +1,83 @@
+package datastore
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kenty51107/task-matcher/internal/app/domain/model"
+	"github.com/kenty51107/task-matcher/internal/app/usecase/repository"
+	"gorm.io/gorm"
+)
+
+type taskDatastore struct {
+    DB *gorm.DB
+}
+
+func NewTaskDatastore(DB *gorm.DB) repository.ITaskRepository {
+    return &taskDatastore{DB}
+}
+
+func (td *taskDatastore) FindTaskByID(taskId int) (*model.Task, error) {
+    row := &model.Task{ID: taskId}
+    if err := td.DB.First(row).Error; err != nil {
+        return nil, err
+    }
+    return row, nil
+}
+
+func (td *taskDatastore) FindTasks() ([]*model.Task, error) {
+    rows  := []*model.Task{}
+    if err := td.DB.Find(&rows).Error; err != nil {
+        return nil, err
+    }
+    return rows, nil
+}
+
+func (td *taskDatastore) CreateTask(input *model.CreateTaskInput) (*model.Task, error) {
+    row := &model.Task{
+        Title: input.Title,
+        Content: input.Content,
+        Schedule: input.Schedule,
+        Done: input.Done,
+        CreatedAt: time.Now(),
+        UpdatedAt: time.Now(),
+    }
+
+    if err := td.DB.Create(row).Error; err != nil {
+        return nil, err
+    }
+    return row, nil
+}
+
+func (td *taskDatastore) UpdateTask(input *model.UpdateTaskInput) (*model.Task, error) {
+    row := &model.Task{}
+    if err := td.DB.Where("id = ?", input.ID).First(row).Error; err != nil {
+        return nil, err
+    }
+    if input.Title != nil {
+        row.Title = *input.Title
+    }
+    if input.Content != nil {
+        row.Content = *input.Content
+    }
+    if input.Schedule != nil {
+        row.Schedule = *input.Schedule
+    }
+    if input.Done != nil {
+        row.Done = *input.Done
+    }
+    row.UpdatedAt = time.Now()
+
+    return row, nil
+}
+
+func (td *taskDatastore) DeleteTask(input *model.DeleteTaskInput) (*model.Task, error) {
+    row := td.DB.Where("id = ?", input.ID).Delete(&model.Task{})
+    if row.Error != nil {
+        return nil, row.Error
+    }
+    if row.RowsAffected < 1 {
+        return nil, fmt.Errorf("no task records found")
+    }
+    return nil, nil
+}

--- a/internal/app/infra/datastore/task_datastore.go
+++ b/internal/app/infra/datastore/task_datastore.go
@@ -17,8 +17,8 @@ func NewTaskDatastore(DB *gorm.DB) repository.ITaskRepository {
     return &taskDatastore{DB}
 }
 
-func (td *taskDatastore) FindTaskByID(taskId int) (*model.Task, error) {
-    row := &model.Task{ID: taskId}
+func (td *taskDatastore) FindTaskByID(taskID int) (*model.Task, error) {
+    row := &model.Task{ID: taskID}
     if err := td.DB.First(row).Error; err != nil {
         return nil, err
     }
@@ -34,18 +34,15 @@ func (td *taskDatastore) FindTasks() ([]*model.Task, error) {
 }
 
 func (td *taskDatastore) CreateTask(input *model.CreateTaskInput) (*model.Task, error) {
+    timestamp := time.Now()
     row := &model.Task{
         Title: input.Title,
         Content: input.Content,
         Schedule: input.Schedule,
         Done: input.Done,
-        CreatedAt: time.Now(),
-        UpdatedAt: time.Now(),
+        CreatedAt: timestamp,
+        UpdatedAt: timestamp,
     }
-    if input.Schedule.IsZero() {
-        row.Schedule = time.Now()
-    }
-
     if err := td.DB.Create(row).Error; err != nil {
         return nil, err
     }
@@ -70,6 +67,10 @@ func (td *taskDatastore) UpdateTask(input *model.UpdateTaskInput) (*model.Task, 
         row.Done = *input.Done
     }
     row.UpdatedAt = time.Now()
+
+    if err := td.DB.Save(row).Error; err != nil {
+        return nil, err
+    }
 
     return row, nil
 }

--- a/internal/app/infra/datastore/task_datastore.go
+++ b/internal/app/infra/datastore/task_datastore.go
@@ -42,6 +42,9 @@ func (td *taskDatastore) CreateTask(input *model.CreateTaskInput) (*model.Task, 
         CreatedAt: time.Now(),
         UpdatedAt: time.Now(),
     }
+    if input.Schedule.IsZero() {
+        row.Schedule = time.Now()
+    }
 
     if err := td.DB.Create(row).Error; err != nil {
         return nil, err
@@ -71,13 +74,13 @@ func (td *taskDatastore) UpdateTask(input *model.UpdateTaskInput) (*model.Task, 
     return row, nil
 }
 
-func (td *taskDatastore) DeleteTask(input *model.DeleteTaskInput) (*model.Task, error) {
+func (td *taskDatastore) DeleteTask(input *model.DeleteTaskInput) error {
     row := td.DB.Where("id = ?", input.ID).Delete(&model.Task{})
     if row.Error != nil {
-        return nil, row.Error
+        return row.Error
     }
     if row.RowsAffected < 1 {
-        return nil, fmt.Errorf("no task records found")
+        return fmt.Errorf("no task records found")
     }
-    return nil, nil
+    return nil
 }

--- a/internal/app/usecase/port/task_port.go
+++ b/internal/app/usecase/port/task_port.go
@@ -14,7 +14,7 @@ type ITaskPort interface {
     FindTasks() ([]*model.Task, error)
     CreateTask(*model.CreateTaskInput) (*model.Task, error)
     UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
-    DeleteTask(*model.DeleteTaskInput) (*model.Task, error)
+    DeleteTask(*model.DeleteTaskInput) error
 }
 
 func NewTaskPort(ts service.ITaskService) ITaskPort {
@@ -37,6 +37,6 @@ func (tp *taskPort) UpdateTask(input *model.UpdateTaskInput) (*model.Task, error
     return tp.ts.UpdateTask(input)
 }
 
-func (tp *taskPort) DeleteTask(input *model.DeleteTaskInput) (*model.Task, error) {
+func (tp *taskPort) DeleteTask(input *model.DeleteTaskInput) error {
     return tp.ts.DeleteTask(input)
 }

--- a/internal/app/usecase/port/task_port.go
+++ b/internal/app/usecase/port/task_port.go
@@ -10,7 +10,7 @@ type taskPort struct {
 }
 
 type ITaskPort interface {
-    FindTaskByID(taskId int) (*model.Task, error)
+    FindTaskByID(taskID int) (*model.Task, error)
     FindTasks() ([]*model.Task, error)
     CreateTask(*model.CreateTaskInput) (*model.Task, error)
     UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
@@ -21,8 +21,8 @@ func NewTaskPort(ts service.ITaskService) ITaskPort {
     return &taskPort{ts}
 }
 
-func (tp *taskPort) FindTaskByID(taskId int) (*model.Task, error) {
-    return tp.ts.FindTaskByID(taskId)
+func (tp *taskPort) FindTaskByID(taskID int) (*model.Task, error) {
+    return tp.ts.FindTaskByID(taskID)
 }
 
 func (tp *taskPort) FindTasks() ([]*model.Task, error) {

--- a/internal/app/usecase/port/task_port.go
+++ b/internal/app/usecase/port/task_port.go
@@ -1,0 +1,42 @@
+package port
+
+import (
+	"github.com/kenty51107/task-matcher/internal/app/domain/model"
+	"github.com/kenty51107/task-matcher/internal/app/domain/service"
+)
+
+type taskPort struct {
+    ts service.ITaskService
+}
+
+type ITaskPort interface {
+    FindTaskByID(taskId int) (*model.Task, error)
+    FindTasks() ([]*model.Task, error)
+    CreateTask(*model.CreateTaskInput) (*model.Task, error)
+    UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
+    DeleteTask(*model.DeleteTaskInput) (*model.Task, error)
+}
+
+func NewTaskPort(ts service.ITaskService) ITaskPort {
+    return &taskPort{ts}
+}
+
+func (tp *taskPort) FindTaskByID(taskId int) (*model.Task, error) {
+    return tp.ts.FindTaskByID(taskId)
+}
+
+func (tp *taskPort) FindTasks() ([]*model.Task, error) {
+    return tp.ts.FindTasks()
+}
+
+func (tp *taskPort) CreateTask(input *model.CreateTaskInput) (*model.Task, error) {
+    return tp.ts.CreateTask(input)
+}
+
+func (tp *taskPort) UpdateTask(input *model.UpdateTaskInput) (*model.Task, error) {
+    return tp.ts.UpdateTask(input)
+}
+
+func (tp *taskPort) DeleteTask(input *model.DeleteTaskInput) (*model.Task, error) {
+    return tp.ts.DeleteTask(input)
+}

--- a/internal/app/usecase/repository/task_repository.go
+++ b/internal/app/usecase/repository/task_repository.go
@@ -1,0 +1,11 @@
+package repository
+
+import "github.com/kenty51107/task-matcher/internal/app/domain/model"
+
+type ITaskRepository interface {
+    FindTaskByID(taskId int) (*model.Task, error)
+    FindTasks() ([]*model.Task, error)
+    CreateTask(*model.CreateTaskInput) (*model.Task, error)
+    UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
+    DeleteTask(*model.DeleteTaskInput) (*model.Task, error)
+}

--- a/internal/app/usecase/repository/task_repository.go
+++ b/internal/app/usecase/repository/task_repository.go
@@ -7,5 +7,5 @@ type ITaskRepository interface {
     FindTasks() ([]*model.Task, error)
     CreateTask(*model.CreateTaskInput) (*model.Task, error)
     UpdateTask(*model.UpdateTaskInput) (*model.Task, error)
-    DeleteTask(*model.DeleteTaskInput) (*model.Task, error)
+    DeleteTask(*model.DeleteTaskInput) error
 }

--- a/internal/app/usecase/repository/task_repository.go
+++ b/internal/app/usecase/repository/task_repository.go
@@ -3,7 +3,7 @@ package repository
 import "github.com/kenty51107/task-matcher/internal/app/domain/model"
 
 type ITaskRepository interface {
-    FindTaskByID(taskId int) (*model.Task, error)
+    FindTaskByID(taskID int) (*model.Task, error)
     FindTasks() ([]*model.Task, error)
     CreateTask(*model.CreateTaskInput) (*model.Task, error)
     UpdateTask(*model.UpdateTaskInput) (*model.Task, error)

--- a/internal/app/usecase/service/task_service.go
+++ b/internal/app/usecase/service/task_service.go
@@ -46,10 +46,10 @@ func (ts *taskService) UpdateTask(input *model.UpdateTaskInput) (*model.Task, er
     return row, nil
 }
 
-func (ts *taskService) DeleteTask(input *model.DeleteTaskInput) (*model.Task, error) {
-    row, err := ts.tr.DeleteTask(input)
+func (ts *taskService) DeleteTask(input *model.DeleteTaskInput) error {
+    err := ts.tr.DeleteTask(input)
     if err != nil {
-        return nil, err
+        return err
     }
-    return row, nil
+    return nil
 }

--- a/internal/app/usecase/service/task_service.go
+++ b/internal/app/usecase/service/task_service.go
@@ -14,8 +14,8 @@ func NewTaskService(tr repository.ITaskRepository) service.ITaskService {
     return &taskService{tr}
 }
 
-func (ts *taskService) FindTaskByID(taskId int) (*model.Task, error) {
-    row, err := ts.tr.FindTaskByID(taskId)
+func (ts *taskService) FindTaskByID(taskID int) (*model.Task, error) {
+    row, err := ts.tr.FindTaskByID(taskID)
     if err != nil {
         return nil, err
     }

--- a/internal/app/usecase/service/task_service.go
+++ b/internal/app/usecase/service/task_service.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"github.com/kenty51107/task-matcher/internal/app/domain/model"
+	"github.com/kenty51107/task-matcher/internal/app/domain/service"
+	"github.com/kenty51107/task-matcher/internal/app/usecase/repository"
+)
+
+type taskService struct {
+    tr repository.ITaskRepository
+}
+
+func NewTaskService(tr repository.ITaskRepository) service.ITaskService {
+    return &taskService{tr}
+}
+
+func (ts *taskService) FindTaskByID(taskId int) (*model.Task, error) {
+    row, err := ts.tr.FindTaskByID(taskId)
+    if err != nil {
+        return nil, err
+    }
+    return row, nil
+}
+
+func (ts *taskService) FindTasks() ([]*model.Task, error) {
+    rows, err := ts.tr.FindTasks()
+    if err != nil {
+        return nil, err
+    }
+    return rows, nil
+}
+
+func (ts *taskService) CreateTask(input *model.CreateTaskInput) (*model.Task, error) {
+    row, err := ts.tr.CreateTask(input)
+    if err != nil {
+        return nil, err
+    }
+    return row, nil
+}
+
+func (ts *taskService) UpdateTask(input *model.UpdateTaskInput) (*model.Task, error) {
+    row, err := ts.tr.UpdateTask(input)
+    if err != nil {
+        return nil, err
+    }
+    return row, nil
+}
+
+func (ts *taskService) DeleteTask(input *model.DeleteTaskInput) (*model.Task, error) {
+    row, err := ts.tr.DeleteTask(input)
+    if err != nil {
+        return nil, err
+    }
+    return row, nil
+}


### PR DESCRIPTION
** 概要
- CRUDの実装

** 詳細
- Mutation(deleteTask)を追加
- CRUD機能を追加 (playgroundで動作確認済み)
- taskSeedを追加
- server.goにエンドポイントを生成する関数(RegisterServer())を追加


////////////////////////////////////
** 概要

- CRUDを実装中

** 詳細

- taskDelete以外(おそらく)実装完了(未テスト)


Q1. gqlgenで自動生成されたresolver(adapter/handler/schema.resolvers.go)のdeleteのmutationの返り値に
　task構造体のポインタが指定されている.
　そこで以下の３項目がわかりません.
   - なぜレコードは削除されたのに構造体を返すのか？その構造体には何が入っているのか？
   - errorのみを返すのはダメなのか？
   - それともresolverの方を変更してもよいのか？
   


申し訳ないけど, 教えてください.